### PR TITLE
perf: 优化数据权限依赖

### DIFF
--- a/ruoyi-fastapi-backend/common/aspect/data_scope.py
+++ b/ruoyi-fastapi-backend/common/aspect/data_scope.py
@@ -1,8 +1,12 @@
 from typing import Optional
 
 from fastapi import Depends, Request, params
+from sqlalchemy import ColumnElement, func, or_, select
 
 from common.context import RequestContext
+from config.database import Base
+from module_admin.entity.do.dept_do import SysDept
+from module_admin.entity.do.role_do import SysRoleDept
 from utils.dependency_util import DependencyUtil
 
 
@@ -19,25 +23,22 @@ class GetDataScope:
 
     def __init__(
         self,
-        query_alias: Optional[str] = '',
-        db_alias: Optional[str] = 'db',
+        query_alias: Base,
         user_alias: Optional[str] = 'user_id',
         dept_alias: Optional[str] = 'dept_id',
     ) -> None:
         """
         获取当前用户数据权限对应的查询sql语句
 
-        :param query_alias: 所要查询表对应的sqlalchemy模型名称，默认为''
-        :param db_alias: orm对象别名，默认为'db'
+        :param query_alias: 所要查询表对应的sqlalchemy模型类，不可为空
         :param user_alias: 用户id字段别名，默认为'user_id'
         :param dept_alias: 部门id字段别名，默认为'dept_id'
         """
         self.query_alias = query_alias
-        self.db_alias = db_alias
         self.user_alias = user_alias
         self.dept_alias = dept_alias
 
-    def __call__(self, request: Request) -> str:
+    def __call__(self, request: Request) -> ColumnElement:
         DependencyUtil.check_exclude_routes(request, err_msg='当前路由不在认证规则内，不可使用GetDataScope依赖项')
         current_user = RequestContext.get_current_user()
         user_id = current_user.user.user_id
@@ -48,50 +49,66 @@ class GetDataScope:
         param_sql_list = []
         for role in current_user.user.role:
             if current_user.user.admin or role.data_scope == self.DATA_SCOPE_ALL:
-                param_sql_list = ['1 == 1']
+                param_sql_list = [True]
                 break
             if role.data_scope == self.DATA_SCOPE_CUSTOM:
                 if len(custom_data_scope_role_id_list) > 1:
                     param_sql_list.append(
-                        f"{self.query_alias}.{self.dept_alias}.in_(select(SysRoleDept.dept_id).where(SysRoleDept.role_id.in_({custom_data_scope_role_id_list}))) if hasattr({self.query_alias}, '{self.dept_alias}') else 1 == 0"
+                        getattr(self.query_alias, self.dept_alias).in_(
+                            select(SysRoleDept.dept_id).where(SysRoleDept.role_id.in_(custom_data_scope_role_id_list))
+                        )
+                        if hasattr(self.query_alias, self.dept_alias)
+                        else False
                     )
                 else:
                     param_sql_list.append(
-                        f"{self.query_alias}.{self.dept_alias}.in_(select(SysRoleDept.dept_id).where(SysRoleDept.role_id == {role.role_id})) if hasattr({self.query_alias}, '{self.dept_alias}') else 1 == 0"
+                        getattr(self.query_alias, self.dept_alias).in_(
+                            select(SysRoleDept.dept_id).where(SysRoleDept.role_id == role.role_id)
+                        )
+                        if hasattr(self.query_alias, self.dept_alias)
+                        else False
                     )
             elif role.data_scope == self.DATA_SCOPE_DEPT:
                 param_sql_list.append(
-                    f"{self.query_alias}.{self.dept_alias} == {dept_id} if hasattr({self.query_alias}, '{self.dept_alias}') else 1 == 0"
+                    getattr(self.query_alias, self.dept_alias) == dept_id
+                    if hasattr(self.query_alias, self.dept_alias)
+                    else False
                 )
             elif role.data_scope == self.DATA_SCOPE_DEPT_AND_CHILD:
                 param_sql_list.append(
-                    f"{self.query_alias}.{self.dept_alias}.in_(select(SysDept.dept_id).where(or_(SysDept.dept_id == {dept_id}, func.find_in_set({dept_id}, SysDept.ancestors)))) if hasattr({self.query_alias}, '{self.dept_alias}') else 1 == 0"
+                    getattr(self.query_alias, self.dept_alias).in_(
+                        select(SysDept.dept_id).where(
+                            or_(SysDept.dept_id == dept_id, func.find_in_set(dept_id, SysDept.ancestors))
+                        )
+                    )
+                    if hasattr(self.query_alias, self.dept_alias)
+                    else False
                 )
             elif role.data_scope == self.DATA_SCOPE_SELF:
                 param_sql_list.append(
-                    f"{self.query_alias}.{self.user_alias} == {user_id} if hasattr({self.query_alias}, '{self.user_alias}') else 1 == 0"
+                    getattr(self.query_alias, self.user_alias) == user_id
+                    if hasattr(self.query_alias, self.user_alias)
+                    else False
                 )
             else:
-                param_sql_list.append('1 == 0')
+                param_sql_list.append(False)
         param_sql_list = list(dict.fromkeys(param_sql_list))
-        param_sql = f'or_({", ".join(param_sql_list)})'
+        param_sql = or_(*param_sql_list)
 
         return param_sql
 
 
 def DataScopeDependency(  # noqa: N802
-    query_alias: Optional[str] = '',
-    db_alias: Optional[str] = 'db',
+    query_alias: Base,
     user_alias: Optional[str] = 'user_id',
     dept_alias: Optional[str] = 'dept_id',
 ) -> params.Depends:
     """
     当前用户数据权限依赖
 
-    :param query_alias: 所要查询表对应的sqlalchemy模型名称，默认为''
-    :param db_alias: orm对象别名，默认为'db'
+    :param query_alias: 所要查询表对应的sqlalchemy模型类，不可为空
     :param user_alias: 用户id字段别名，默认为'user_id'
     :param dept_alias: 部门id字段别名，默认为'dept_id'
     :return: 当前用户数据权限依赖
     """
-    return Depends(GetDataScope(query_alias, db_alias, user_alias, dept_alias))
+    return Depends(GetDataScope(query_alias, user_alias, dept_alias))

--- a/ruoyi-fastapi-backend/module_admin/controller/dept_controller.py
+++ b/ruoyi-fastapi-backend/module_admin/controller/dept_controller.py
@@ -3,6 +3,7 @@ from typing import Annotated
 
 from fastapi import Path, Query, Request, Response
 from pydantic_validation_decorator import ValidateFields
+from sqlalchemy import ColumnElement
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from common.annotation.log_annotation import Log
@@ -13,6 +14,7 @@ from common.aspect.pre_auth import CurrentUserDependency, PreAuthDependency
 from common.enums import BusinessType
 from common.router import APIRouterPro
 from common.vo import DataResponseModel, ResponseBaseModel
+from module_admin.entity.do.dept_do import SysDept
 from module_admin.entity.vo.dept_vo import DeleteDeptModel, DeptModel, DeptQueryModel
 from module_admin.entity.vo.user_vo import CurrentUserModel
 from module_admin.service.dept_service import DeptService
@@ -35,7 +37,7 @@ async def get_system_dept_tree_for_edit_option(
     request: Request,
     dept_id: Annotated[int, Path(description='部门id')],
     query_db: Annotated[AsyncSession, DBSessionDependency()],
-    data_scope_sql: Annotated[str, DataScopeDependency('SysDept')],
+    data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysDept)],
 ) -> Response:
     dept_query = DeptModel(deptId=dept_id)
     dept_query_result = await DeptService.get_dept_for_edit_option_services(query_db, dept_query, data_scope_sql)
@@ -55,7 +57,7 @@ async def get_system_dept_list(
     request: Request,
     dept_query: Annotated[DeptQueryModel, Query()],
     query_db: Annotated[AsyncSession, DBSessionDependency()],
-    data_scope_sql: Annotated[str, DataScopeDependency('SysDept')],
+    data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysDept)],
 ) -> Response:
     dept_query_result = await DeptService.get_dept_list_services(query_db, dept_query, data_scope_sql)
     logger.info('获取成功')
@@ -102,7 +104,7 @@ async def edit_system_dept(
     edit_dept: DeptModel,
     query_db: Annotated[AsyncSession, DBSessionDependency()],
     current_user: Annotated[CurrentUserModel, CurrentUserDependency()],
-    data_scope_sql: Annotated[str, DataScopeDependency('SysDept')],
+    data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysDept)],
 ) -> Response:
     if not current_user.user.admin:
         await DeptService.check_dept_data_scope_services(query_db, edit_dept.dept_id, data_scope_sql)
@@ -127,7 +129,7 @@ async def delete_system_dept(
     dept_ids: Annotated[str, Path(description='需要删除的部门id')],
     query_db: Annotated[AsyncSession, DBSessionDependency()],
     current_user: Annotated[CurrentUserModel, CurrentUserDependency()],
-    data_scope_sql: Annotated[str, DataScopeDependency('SysDept')],
+    data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysDept)],
 ) -> Response:
     dept_id_list = dept_ids.split(',') if dept_ids else []
     if dept_id_list:
@@ -155,7 +157,7 @@ async def query_detail_system_dept(
     dept_id: Annotated[int, Path(description='部门id')],
     query_db: Annotated[AsyncSession, DBSessionDependency()],
     current_user: Annotated[CurrentUserModel, CurrentUserDependency()],
-    data_scope_sql: Annotated[str, DataScopeDependency('SysDept')],
+    data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysDept)],
 ) -> Response:
     if not current_user.user.admin:
         await DeptService.check_dept_data_scope_services(query_db, dept_id, data_scope_sql)

--- a/ruoyi-fastapi-backend/module_admin/controller/role_controller.py
+++ b/ruoyi-fastapi-backend/module_admin/controller/role_controller.py
@@ -4,6 +4,7 @@ from typing import Annotated
 from fastapi import Form, Path, Query, Request, Response
 from fastapi.responses import StreamingResponse
 from pydantic_validation_decorator import ValidateFields
+from sqlalchemy import ColumnElement
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from common.annotation.log_annotation import Log
@@ -14,6 +15,8 @@ from common.aspect.pre_auth import CurrentUserDependency, PreAuthDependency
 from common.enums import BusinessType
 from common.router import APIRouterPro
 from common.vo import DataResponseModel, DynamicResponseModel, PageResponseModel, ResponseBaseModel
+from module_admin.entity.do.dept_do import SysDept
+from module_admin.entity.do.user_do import SysUser
 from module_admin.entity.vo.dept_vo import DeptModel
 from module_admin.entity.vo.role_vo import (
     AddRoleModel,
@@ -46,7 +49,7 @@ async def get_system_role_dept_tree(
     request: Request,
     role_id: Annotated[int, Path(description='角色ID')],
     query_db: Annotated[AsyncSession, DBSessionDependency()],
-    data_scope_sql: Annotated[str, DataScopeDependency('SysDept')],
+    data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysDept)],
 ) -> Response:
     dept_query_result = await DeptService.get_dept_tree_services(query_db, DeptModel(), data_scope_sql)
     role_dept_query_result = await RoleService.get_role_dept_tree_services(query_db, role_id)
@@ -67,7 +70,7 @@ async def get_system_role_list(
     request: Request,
     role_page_query: Annotated[RolePageQueryModel, Query()],
     query_db: Annotated[AsyncSession, DBSessionDependency()],
-    data_scope_sql: Annotated[str, DataScopeDependency('SysDept')],
+    data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysDept)],
 ) -> Response:
     role_page_query_result = await RoleService.get_role_list_services(
         query_db, role_page_query, data_scope_sql, is_page=True
@@ -116,7 +119,7 @@ async def edit_system_role(
     edit_role: AddRoleModel,
     query_db: Annotated[AsyncSession, DBSessionDependency()],
     current_user: Annotated[CurrentUserModel, CurrentUserDependency()],
-    data_scope_sql: Annotated[str, DataScopeDependency('SysDept')],
+    data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysDept)],
 ) -> Response:
     await RoleService.check_role_allowed_services(edit_role)
     if not current_user.user.admin:
@@ -142,7 +145,7 @@ async def edit_system_role_datascope(
     role_data_scope: AddRoleModel,
     query_db: Annotated[AsyncSession, DBSessionDependency()],
     current_user: Annotated[CurrentUserModel, CurrentUserDependency()],
-    data_scope_sql: Annotated[str, DataScopeDependency('SysDept')],
+    data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysDept)],
 ) -> Response:
     await RoleService.check_role_allowed_services(role_data_scope)
     if not current_user.user.admin:
@@ -174,7 +177,7 @@ async def delete_system_role(
     role_ids: Annotated[str, Path(description='需要删除的角色ID')],
     query_db: Annotated[AsyncSession, DBSessionDependency()],
     current_user: Annotated[CurrentUserModel, CurrentUserDependency()],
-    data_scope_sql: Annotated[str, DataScopeDependency('SysDept')],
+    data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysDept)],
 ) -> Response:
     role_id_list = role_ids.split(',') if role_ids else []
     if role_id_list:
@@ -201,7 +204,7 @@ async def query_detail_system_role(
     role_id: Annotated[int, Path(description='角色ID')],
     query_db: Annotated[AsyncSession, DBSessionDependency()],
     current_user: Annotated[CurrentUserModel, CurrentUserDependency()],
-    data_scope_sql: Annotated[str, DataScopeDependency('SysDept')],
+    data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysDept)],
 ) -> Response:
     if not current_user.user.admin:
         await RoleService.check_role_data_scope_services(query_db, str(role_id), data_scope_sql)
@@ -231,7 +234,7 @@ async def export_system_role_list(
     request: Request,
     role_page_query: Annotated[RolePageQueryModel, Form()],
     query_db: Annotated[AsyncSession, DBSessionDependency()],
-    data_scope_sql: Annotated[str, DataScopeDependency('SysDept')],
+    data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysDept)],
 ) -> Response:
     # 获取全量数据
     role_query_result = await RoleService.get_role_list_services(
@@ -256,7 +259,7 @@ async def reset_system_role_status(
     change_role: AddRoleModel,
     query_db: Annotated[AsyncSession, DBSessionDependency()],
     current_user: Annotated[CurrentUserModel, CurrentUserDependency()],
-    data_scope_sql: Annotated[str, DataScopeDependency('SysDept')],
+    data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysDept)],
 ) -> Response:
     await RoleService.check_role_allowed_services(change_role)
     if not current_user.user.admin:
@@ -285,7 +288,7 @@ async def get_system_allocated_user_list(
     request: Request,
     user_role: Annotated[UserRolePageQueryModel, Query()],
     query_db: Annotated[AsyncSession, DBSessionDependency()],
-    data_scope_sql: Annotated[str, DataScopeDependency('SysUser')],
+    data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysUser)],
 ) -> Response:
     role_user_allocated_page_query_result = await RoleService.get_role_user_allocated_list_services(
         query_db, user_role, data_scope_sql, is_page=True
@@ -306,7 +309,7 @@ async def get_system_unallocated_user_list(
     request: Request,
     user_role: Annotated[UserRolePageQueryModel, Query()],
     query_db: Annotated[AsyncSession, DBSessionDependency()],
-    data_scope_sql: Annotated[str, DataScopeDependency('SysUser')],
+    data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysUser)],
 ) -> Response:
     role_user_unallocated_page_query_result = await RoleService.get_role_user_unallocated_list_services(
         query_db, user_role, data_scope_sql, is_page=True
@@ -329,7 +332,7 @@ async def add_system_role_user(
     add_role_user: Annotated[CrudUserRoleModel, Query()],
     query_db: Annotated[AsyncSession, DBSessionDependency()],
     current_user: Annotated[CurrentUserModel, CurrentUserDependency()],
-    data_scope_sql: Annotated[str, DataScopeDependency('SysDept')],
+    data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysDept)],
 ) -> Response:
     if not current_user.user.admin:
         await RoleService.check_role_data_scope_services(query_db, str(add_role_user.role_id), data_scope_sql)

--- a/ruoyi-fastapi-backend/module_admin/controller/user_controller.py
+++ b/ruoyi-fastapi-backend/module_admin/controller/user_controller.py
@@ -6,6 +6,7 @@ import aiofiles
 from fastapi import File, Form, Path, Query, Request, Response, UploadFile
 from fastapi.responses import StreamingResponse
 from pydantic_validation_decorator import ValidateFields
+from sqlalchemy import ColumnElement
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from common.annotation.log_annotation import Log
@@ -17,6 +18,8 @@ from common.enums import BusinessType
 from common.router import APIRouterPro
 from common.vo import DataResponseModel, DynamicResponseModel, PageResponseModel, ResponseBaseModel
 from config.env import UploadConfig
+from module_admin.entity.do.dept_do import SysDept
+from module_admin.entity.do.user_do import SysUser
 from module_admin.entity.vo.dept_vo import DeptModel, DeptTreeModel
 from module_admin.entity.vo.user_vo import (
     AddUserModel,
@@ -60,7 +63,7 @@ user_controller = APIRouterPro(
 async def get_system_dept_tree(
     request: Request,
     query_db: Annotated[AsyncSession, DBSessionDependency()],
-    data_scope_sql: Annotated[str, DataScopeDependency('SysDept')],
+    data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysDept)],
 ) -> Response:
     dept_query_result = await DeptService.get_dept_tree_services(query_db, DeptModel(), data_scope_sql)
     logger.info('获取成功')
@@ -79,7 +82,7 @@ async def get_system_user_list(
     request: Request,
     user_page_query: Annotated[UserPageQueryModel, Query()],
     query_db: Annotated[AsyncSession, DBSessionDependency()],
-    data_scope_sql: Annotated[str, DataScopeDependency('SysUser')],
+    data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysUser)],
 ) -> Response:
     # 获取分页数据
     user_page_query_result = await UserService.get_user_list_services(
@@ -104,8 +107,8 @@ async def add_system_user(
     add_user: AddUserModel,
     query_db: Annotated[AsyncSession, DBSessionDependency()],
     current_user: Annotated[CurrentUserModel, CurrentUserDependency()],
-    dept_data_scope_sql: Annotated[str, DataScopeDependency('SysDept')],
-    role_data_scope_sql: Annotated[str, DataScopeDependency('SysDept')],
+    dept_data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysDept)],
+    role_data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysDept)],
 ) -> Response:
     if not current_user.user.admin:
         await DeptService.check_dept_data_scope_services(query_db, add_user.dept_id, dept_data_scope_sql)
@@ -137,9 +140,9 @@ async def edit_system_user(
     edit_user: EditUserModel,
     query_db: Annotated[AsyncSession, DBSessionDependency()],
     current_user: Annotated[CurrentUserModel, CurrentUserDependency()],
-    user_data_scope_sql: Annotated[str, DataScopeDependency('SysUser')],
-    dept_data_scope_sql: Annotated[str, DataScopeDependency('SysDept')],
-    role_data_scope_sql: Annotated[str, DataScopeDependency('SysDept')],
+    user_data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysUser)],
+    dept_data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysDept)],
+    role_data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysDept)],
 ) -> Response:
     await UserService.check_user_allowed_services(edit_user)
     if not current_user.user.admin:
@@ -169,7 +172,7 @@ async def delete_system_user(
     user_ids: Annotated[str, Path(description='需要删除的用户ID')],
     query_db: Annotated[AsyncSession, DBSessionDependency()],
     current_user: Annotated[CurrentUserModel, CurrentUserDependency()],
-    data_scope_sql: Annotated[str, DataScopeDependency('SysUser')],
+    data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysUser)],
 ) -> Response:
     user_id_list = user_ids.split(',') if user_ids else []
     if user_id_list:
@@ -201,7 +204,7 @@ async def reset_system_user_pwd(
     reset_user: EditUserModel,
     query_db: Annotated[AsyncSession, DBSessionDependency()],
     current_user: Annotated[CurrentUserModel, CurrentUserDependency()],
-    data_scope_sql: Annotated[str, DataScopeDependency('SysUser')],
+    data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysUser)],
 ) -> Response:
     await UserService.check_user_allowed_services(reset_user)
     if not current_user.user.admin:
@@ -233,7 +236,7 @@ async def change_system_user_status(
     change_user: EditUserModel,
     query_db: Annotated[AsyncSession, DBSessionDependency()],
     current_user: Annotated[CurrentUserModel, CurrentUserDependency()],
-    data_scope_sql: Annotated[str, DataScopeDependency('SysUser')],
+    data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysUser)],
 ) -> Response:
     await UserService.check_user_allowed_services(change_user)
     if not current_user.user.admin:
@@ -286,7 +289,7 @@ async def query_detail_system_user(
     request: Request,
     query_db: Annotated[AsyncSession, DBSessionDependency()],
     current_user: Annotated[CurrentUserModel, CurrentUserDependency()],
-    data_scope_sql: Annotated[str, DataScopeDependency('SysUser')],
+    data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysUser)],
     user_id: Optional[Union[int, Literal['']]] = '',
 ) -> Response:
     if user_id and not current_user.user.admin:
@@ -407,8 +410,8 @@ async def batch_import_system_user(
     update_support: Annotated[bool, Query(alias='updateSupport')],
     query_db: Annotated[AsyncSession, DBSessionDependency()],
     current_user: Annotated[CurrentUserModel, CurrentUserDependency()],
-    user_data_scope_sql: Annotated[str, DataScopeDependency('SysUser')],
-    dept_data_scope_sql: Annotated[str, DataScopeDependency('SysDept')],
+    user_data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysUser)],
+    dept_data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysDept)],
 ) -> Response:
     batch_import_result = await UserService.batch_import_user_services(
         request, query_db, file, update_support, current_user, user_data_scope_sql, dept_data_scope_sql
@@ -462,7 +465,7 @@ async def export_system_user_list(
     request: Request,
     user_page_query: Annotated[UserPageQueryModel, Form()],
     query_db: Annotated[AsyncSession, DBSessionDependency()],
-    data_scope_sql: Annotated[str, DataScopeDependency('SysUser')],
+    data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysUser)],
 ) -> Response:
     # 获取全量数据
     user_query_result = await UserService.get_user_list_services(
@@ -509,8 +512,8 @@ async def update_system_role_user(
     role_ids: Annotated[str, Query(alias='roleIds')],
     query_db: Annotated[AsyncSession, DBSessionDependency()],
     current_user: Annotated[CurrentUserModel, CurrentUserDependency()],
-    user_data_scope_sql: Annotated[str, DataScopeDependency('SysUser')],
-    role_data_scope_sql: Annotated[str, DataScopeDependency('SysDept')],
+    user_data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysUser)],
+    role_data_scope_sql: Annotated[ColumnElement, DataScopeDependency(SysDept)],
 ) -> Response:
     if not current_user.user.admin:
         await UserService.check_user_data_scope_services(query_db, user_id, user_data_scope_sql)

--- a/ruoyi-fastapi-backend/module_admin/dao/dept_dao.py
+++ b/ruoyi-fastapi-backend/module_admin/dao/dept_dao.py
@@ -1,12 +1,11 @@
 from collections.abc import Sequence
 from typing import Union
 
-from sqlalchemy import bindparam, func, or_, select, update  # noqa: F401
+from sqlalchemy import ColumnElement, bindparam, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.util import immutabledict
 
 from module_admin.entity.do.dept_do import SysDept
-from module_admin.entity.do.role_do import SysRoleDept  # noqa: F401
 from module_admin.entity.do.user_do import SysUser
 from module_admin.entity.vo.dept_vo import DeptModel
 
@@ -72,7 +71,7 @@ class DeptDao:
 
     @classmethod
     async def get_dept_info_for_edit_option(
-        cls, db: AsyncSession, dept_info: DeptModel, data_scope_sql: str
+        cls, db: AsyncSession, dept_info: DeptModel, data_scope_sql: ColumnElement
     ) -> Sequence[SysDept]:
         """
         获取部门编辑对应的在用部门列表信息
@@ -93,7 +92,7 @@ class DeptDao:
                         ),
                         SysDept.del_flag == '0',
                         SysDept.status == '0',
-                        eval(data_scope_sql),
+                        data_scope_sql,
                     )
                     .order_by(SysDept.order_num)
                     .distinct()
@@ -122,7 +121,7 @@ class DeptDao:
 
     @classmethod
     async def get_dept_list_for_tree(
-        cls, db: AsyncSession, dept_info: DeptModel, data_scope_sql: str
+        cls, db: AsyncSession, dept_info: DeptModel, data_scope_sql: ColumnElement
     ) -> Sequence[SysDept]:
         """
         获取所有在用部门列表信息
@@ -140,7 +139,7 @@ class DeptDao:
                         SysDept.status == '0',
                         SysDept.del_flag == '0',
                         SysDept.dept_name.like(f'%{dept_info.dept_name}%') if dept_info.dept_name else True,
-                        eval(data_scope_sql),
+                        data_scope_sql,
                     )
                     .order_by(SysDept.order_num)
                     .distinct()
@@ -153,7 +152,9 @@ class DeptDao:
         return dept_result
 
     @classmethod
-    async def get_dept_list(cls, db: AsyncSession, page_object: DeptModel, data_scope_sql: str) -> Sequence[SysDept]:
+    async def get_dept_list(
+        cls, db: AsyncSession, page_object: DeptModel, data_scope_sql: ColumnElement
+    ) -> Sequence[SysDept]:
         """
         根据查询参数获取部门列表信息
 
@@ -171,7 +172,7 @@ class DeptDao:
                         SysDept.dept_id == page_object.dept_id if page_object.dept_id is not None else True,
                         SysDept.status == page_object.status if page_object.status else True,
                         SysDept.dept_name.like(f'%{page_object.dept_name}%') if page_object.dept_name else True,
-                        eval(data_scope_sql),
+                        data_scope_sql,
                     )
                     .order_by(SysDept.order_num)
                     .distinct()

--- a/ruoyi-fastapi-backend/module_admin/dao/role_dao.py
+++ b/ruoyi-fastapi-backend/module_admin/dao/role_dao.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from datetime import datetime, time
 from typing import Any, Union
 
-from sqlalchemy import and_, delete, desc, func, or_, select, update  # noqa: F401
+from sqlalchemy import ColumnElement, and_, delete, desc, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from common.vo import PageModel
@@ -131,7 +131,7 @@ class RoleDao:
 
     @classmethod
     async def get_role_list(
-        cls, db: AsyncSession, query_object: RolePageQueryModel, data_scope_sql: str, is_page: bool = False
+        cls, db: AsyncSession, query_object: RolePageQueryModel, data_scope_sql: ColumnElement, is_page: bool = False
     ) -> Union[PageModel, list[dict[str, Any]]]:
         """
         根据查询参数获取角色列表信息
@@ -159,7 +159,7 @@ class RoleDao:
                 )
                 if query_object.begin_time and query_object.end_time
                 else True,
-                eval(data_scope_sql),
+                data_scope_sql,
             )
             .order_by(SysRole.role_sort)
             .distinct()

--- a/ruoyi-fastapi-backend/module_admin/dao/user_dao.py
+++ b/ruoyi-fastapi-backend/module_admin/dao/user_dao.py
@@ -2,14 +2,14 @@ from collections.abc import Sequence
 from datetime import datetime, time
 from typing import Any, Union
 
-from sqlalchemy import and_, delete, desc, func, or_, select, update
+from sqlalchemy import ColumnElement, and_, delete, desc, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from common.vo import PageModel
 from module_admin.entity.do.dept_do import SysDept
 from module_admin.entity.do.menu_do import SysMenu
 from module_admin.entity.do.post_do import SysPost
-from module_admin.entity.do.role_do import SysRole, SysRoleDept, SysRoleMenu  # noqa: F401
+from module_admin.entity.do.role_do import SysRole, SysRoleMenu
 from module_admin.entity.do.user_do import SysUser, SysUserPost, SysUserRole
 from module_admin.entity.vo.user_vo import (
     UserModel,
@@ -280,7 +280,7 @@ class UserDao:
 
     @classmethod
     async def get_user_list(
-        cls, db: AsyncSession, query_object: UserPageQueryModel, data_scope_sql: str, is_page: bool = False
+        cls, db: AsyncSession, query_object: UserPageQueryModel, data_scope_sql: ColumnElement, is_page: bool = False
     ) -> Union[PageModel, list[list[dict[str, Any]]]]:
         """
         根据查询参数获取用户列表信息
@@ -316,7 +316,7 @@ class UserDao:
                 )
                 if query_object.begin_time and query_object.end_time
                 else True,
-                eval(data_scope_sql),
+                data_scope_sql,
             )
             .join(
                 SysDept,
@@ -408,7 +408,11 @@ class UserDao:
 
     @classmethod
     async def get_user_role_allocated_list_by_role_id(
-        cls, db: AsyncSession, query_object: UserRolePageQueryModel, data_scope_sql: str, is_page: bool = False
+        cls,
+        db: AsyncSession,
+        query_object: UserRolePageQueryModel,
+        data_scope_sql: ColumnElement,
+        is_page: bool = False,
     ) -> Union[PageModel, list[dict[str, Any]]]:
         """
         根据角色id获取已分配的用户列表信息
@@ -429,7 +433,7 @@ class UserDao:
                 SysUser.user_name == query_object.user_name if query_object.user_name else True,
                 SysUser.phonenumber == query_object.phonenumber if query_object.phonenumber else True,
                 SysRole.role_id == query_object.role_id,
-                eval(data_scope_sql),
+                data_scope_sql,
             )
             .distinct()
         )
@@ -441,7 +445,11 @@ class UserDao:
 
     @classmethod
     async def get_user_role_unallocated_list_by_role_id(
-        cls, db: AsyncSession, query_object: UserRolePageQueryModel, data_scope_sql: str, is_page: bool = False
+        cls,
+        db: AsyncSession,
+        query_object: UserRolePageQueryModel,
+        data_scope_sql: ColumnElement,
+        is_page: bool = False,
     ) -> Union[PageModel, list[dict[str, Any]]]:
         """
         根据角色id获取未分配的用户列表信息
@@ -470,7 +478,7 @@ class UserDao:
                         and_(SysUserRole.user_id == SysUser.user_id, SysUserRole.role_id == query_object.role_id),
                     )
                 ),
-                eval(data_scope_sql),
+                data_scope_sql,
             )
             .distinct()
         )

--- a/ruoyi-fastapi-backend/module_admin/service/dept_service.py
+++ b/ruoyi-fastapi-backend/module_admin/service/dept_service.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 from typing import Any
 
+from sqlalchemy import ColumnElement
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from common.constant import CommonConstant
@@ -19,7 +20,7 @@ class DeptService:
 
     @classmethod
     async def get_dept_tree_services(
-        cls, query_db: AsyncSession, page_object: DeptModel, data_scope_sql: str
+        cls, query_db: AsyncSession, page_object: DeptModel, data_scope_sql: ColumnElement
     ) -> list[dict[str, Any]]:
         """
         获取部门树信息service
@@ -37,7 +38,7 @@ class DeptService:
 
     @classmethod
     async def get_dept_for_edit_option_services(
-        cls, query_db: AsyncSession, page_object: DeptModel, data_scope_sql: str
+        cls, query_db: AsyncSession, page_object: DeptModel, data_scope_sql: ColumnElement
     ) -> list[dict[str, Any]]:
         """
         获取部门编辑部门树信息service
@@ -53,7 +54,7 @@ class DeptService:
 
     @classmethod
     async def get_dept_list_services(
-        cls, query_db: AsyncSession, page_object: DeptModel, data_scope_sql: str
+        cls, query_db: AsyncSession, page_object: DeptModel, data_scope_sql: ColumnElement
     ) -> list[dict[str, Any]]:
         """
         获取部门列表信息service
@@ -69,7 +70,7 @@ class DeptService:
 
     @classmethod
     async def check_dept_data_scope_services(
-        cls, query_db: AsyncSession, dept_id: int, data_scope_sql: str
+        cls, query_db: AsyncSession, dept_id: int, data_scope_sql: ColumnElement
     ) -> CrudResponseModel:
         """
         校验部门是否有数据权限service

--- a/ruoyi-fastapi-backend/module_admin/service/role_service.py
+++ b/ruoyi-fastapi-backend/module_admin/service/role_service.py
@@ -1,5 +1,6 @@
 from typing import Any, Union
 
+from sqlalchemy import ColumnElement
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from common.constant import CommonConstant
@@ -56,7 +57,11 @@ class RoleService:
 
     @classmethod
     async def get_role_list_services(
-        cls, query_db: AsyncSession, query_object: RolePageQueryModel, data_scope_sql: str, is_page: bool = False
+        cls,
+        query_db: AsyncSession,
+        query_object: RolePageQueryModel,
+        data_scope_sql: ColumnElement,
+        is_page: bool = False,
     ) -> Union[PageModel, list[dict[str, Any]]]:
         """
         获取角色列表信息service
@@ -84,7 +89,9 @@ class RoleService:
         return CrudResponseModel(is_success=True, message='校验通过')
 
     @classmethod
-    async def check_role_data_scope_services(cls, query_db: AsyncSession, role_ids: str, data_scope_sql: str) -> None:
+    async def check_role_data_scope_services(
+        cls, query_db: AsyncSession, role_ids: str, data_scope_sql: ColumnElement
+    ) -> None:
         """
         校验角色是否有数据权限service
 
@@ -304,7 +311,11 @@ class RoleService:
 
     @classmethod
     async def get_role_user_allocated_list_services(
-        cls, query_db: AsyncSession, page_object: UserRolePageQueryModel, data_scope_sql: str, is_page: bool = False
+        cls,
+        query_db: AsyncSession,
+        page_object: UserRolePageQueryModel,
+        data_scope_sql: ColumnElement,
+        is_page: bool = False,
     ) -> PageModel:
         """
         根据角色id获取已分配用户列表
@@ -329,7 +340,11 @@ class RoleService:
 
     @classmethod
     async def get_role_user_unallocated_list_services(
-        cls, query_db: AsyncSession, page_object: UserRolePageQueryModel, data_scope_sql: str, is_page: bool = False
+        cls,
+        query_db: AsyncSession,
+        page_object: UserRolePageQueryModel,
+        data_scope_sql: ColumnElement,
+        is_page: bool = False,
     ) -> PageModel:
         """
         根据角色id获取未分配用户列表

--- a/ruoyi-fastapi-backend/module_admin/service/user_service.py
+++ b/ruoyi-fastapi-backend/module_admin/service/user_service.py
@@ -4,6 +4,7 @@ from typing import Any, Union
 
 import pandas as pd
 from fastapi import Request, UploadFile
+from sqlalchemy import ColumnElement
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from common.constant import CommonConstant
@@ -47,7 +48,11 @@ class UserService:
 
     @classmethod
     async def get_user_list_services(
-        cls, query_db: AsyncSession, query_object: UserPageQueryModel, data_scope_sql: str, is_page: bool = False
+        cls,
+        query_db: AsyncSession,
+        query_object: UserPageQueryModel,
+        data_scope_sql: ColumnElement,
+        is_page: bool = False,
     ) -> Union[PageModel[UserRowModel], list[dict[str, Any]]]:
         """
         获取用户列表信息service
@@ -87,7 +92,7 @@ class UserService:
 
     @classmethod
     async def check_user_data_scope_services(
-        cls, query_db: AsyncSession, user_id: int, data_scope_sql: str
+        cls, query_db: AsyncSession, user_id: int, data_scope_sql: ColumnElement
     ) -> CrudResponseModel:
         """
         校验用户数据权限service
@@ -392,8 +397,8 @@ class UserService:
         file: UploadFile,
         update_support: bool,
         current_user: CurrentUserModel,
-        user_data_scope_sql: str,
-        dept_data_scope_sql: str,
+        user_data_scope_sql: ColumnElement,
+        dept_data_scope_sql: ColumnElement,
     ) -> CrudResponseModel:
         """
         批量导入用户service


### PR DESCRIPTION
此PR做了以下工作：
1.现在数据权限依赖最终返回类型是`ColumnElement`而不是`str`。
2.调整所有与数据权限相关的参数类型。
3.`dao`层弃用`eval`函数，可直接传入数据权限参数，并移除了之前依赖的一些“隐式使用”导入。