### PR TITLE
Remove hardcoded default JWT secret key and database password

### DIFF
--- a/ruoyi-fastapi-backend/config/env.py
+++ b/ruoyi-fastapi-backend/config/env.py
@@ -36,7 +36,7 @@ class JwtSettings(BaseSettings):
     Jwt配置
     """
 
-    jwt_secret_key: str = 'b01c66dc2c58dc6a0aabfe2144256be36226de378bf87f72c0c795dda67f4d55'
+    jwt_secret_key: str = ''  # REQUIRED: Set via JWT_SECRET_KEY env var
     jwt_algorithm: str = 'HS256'
     jwt_expire_minutes: int = 1440
     jwt_redis_expire_minutes: int = 30
@@ -51,7 +51,7 @@ class DataBaseSettings(BaseSettings):
     db_host: str = '127.0.0.1'
     db_port: int = 3306
     db_username: str = 'root'
-    db_password: str = 'mysqlroot'
+    db_password: str = ''  # Set via DB_PASSWORD env var
     db_database: str = 'ruoyi-fastapi'
     db_echo: bool = True
     db_max_overflow: int = 10


### PR DESCRIPTION
## Summary

`ruoyi-fastapi-backend/config/env.py` contained a hardcoded default JWT signing key and a hardcoded default database password, allowing anyone with access to the repository source code to:
1. Forge valid JWT tokens for any user and gain administrative access
2. Connect to the database using known default credentials

## Changes

- Removed hardcoded `jwt_secret_key` default value (was `'b01c66dc2c58dc6a0aabfe2144256be36226de378bf87f72c0c795dda67f4d55'`)
- Removed hardcoded `db_password` default value (was `'mysqlroot'`)
- Both now default to empty string and can be set via environment variables (`JWT_SECRET_KEY`, `DB_PASSWORD`) or `.env` files

## Fixed Vulnerability

- **CWE-798**: Use of Hard-coded Credentials — JWT signing key and database password were hardcoded in version-controlled source code

## Test plan

- [ ] Set `JWT_SECRET_KEY` env var or `.env` value, verify JWT auth works
- [ ] Set `DB_PASSWORD` env var or `.env` value, verify database connection works
- [ ] Verify application fails to validate tokens correctly when JWT key is not configured